### PR TITLE
single sql for models run only when input_material is id_stitcher model

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -8,7 +8,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select sum(user_count) as user_count, max(other_id_count) as max_id_count,
               (sum(user_count * other_id_count)::float / sum(user_count)::float)::numeric(8,2) as avg_id_count
             from (
@@ -31,7 +31,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select count(distinct(node_id)) as id_count, max({{input_material.Model.GetEntity().IdColumnName}}_dist) as max_dist, {{input_material.Model.GetEntity().IdColumnName}}
             from {{input_material}}_INTERNAL_MAPPING
             group by {{input_material.Model.GetEntity().IdColumnName}}
@@ -72,7 +72,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select {{input_material.Model.GetEntity().IdColumnName}} as main_id, node_id, node_id_type, degree
             from (
               select m.{{input_material.Model.GetEntity().IdColumnName}}, e.node_id, e.node_id_type, count(*) as degree, row_number() over (partition by m.{{input_material.Model.GetEntity().IdColumnName}} order by count(*) desc) as rn
@@ -105,7 +105,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/top_max_degree_nodes") %}
-          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
             from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
             where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
@@ -120,7 +120,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/top_max_degree_nodes") input_material3 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material1.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material1.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
             from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
             where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
@@ -136,7 +136,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select A.{{input_material1.Model.GetEntity().IdColumnName}}, max(B.id_count) as total_id_count, 
           other_id_type, count(other_id) as id_type_count
             from {{input_material1}} A inner join {{input_material2}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}
@@ -153,7 +153,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
             select id1_type, id1, count(id1) as total_instances, count(distinct {{input_material1.Model.GetEntity().IdColumnName}}) as merged_user_count
             from {{input_material1}}_INTERNAL_EDGES
             where id1 in (

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -136,7 +136,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.BaseWhtModel.modelType == "id_stitcher_model" %}
             select A.{{input_material1.Model.GetEntity().IdColumnName}}, max(B.id_count) as total_id_count, 
           other_id_type, count(other_id) as id_type_count
             from {{input_material1}} A inner join {{input_material2}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -8,17 +8,19 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          select sum(user_count) as user_count, max(other_id_count) as max_id_count,
-            (sum(user_count * other_id_count)::float / sum(user_count)::float)::numeric(8,2) as avg_id_count
-          from (
-            select other_id_count,  count(distinct {{input_material.Model.GetEntity().IdColumnName}}) as user_count
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+            select sum(user_count) as user_count, max(other_id_count) as max_id_count,
+              (sum(user_count * other_id_count)::float / sum(user_count)::float)::numeric(8,2) as avg_id_count
             from (
-              select {{input_material.Model.GetEntity().IdColumnName}}, count(other_id) as other_id_count
-              from {{input_material}}
-              group by {{input_material.Model.GetEntity().IdColumnName}}
+              select other_id_count,  count(distinct {{input_material.Model.GetEntity().IdColumnName}}) as user_count
+              from (
+                select {{input_material.Model.GetEntity().IdColumnName}}, count(other_id) as other_id_count
+                from {{input_material}}
+                group by {{input_material.Model.GetEntity().IdColumnName}}
+              )
+              group by other_id_count
             )
-            group by other_id_count
-          )
+          {% endif %}
         {% endwith %}
   - name: clusters
     model_type: sql_template
@@ -29,9 +31,11 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          select count(distinct(node_id)) as id_count, max({{input_material.Model.GetEntity().IdColumnName}}_dist) as max_dist, {{input_material.Model.GetEntity().IdColumnName}}
-          from {{input_material}}_INTERNAL_MAPPING
-          group by {{input_material.Model.GetEntity().IdColumnName}}
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+            select count(distinct(node_id)) as id_count, max({{input_material.Model.GetEntity().IdColumnName}}_dist) as max_dist, {{input_material.Model.GetEntity().IdColumnName}}
+            from {{input_material}}_INTERNAL_MAPPING
+            group by {{input_material.Model.GetEntity().IdColumnName}}
+          {% endif %}
         {% endwith %}
   - name: clusters_sorted_by_size
     model_type: sql_template
@@ -68,27 +72,29 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          select {{input_material.Model.GetEntity().IdColumnName}} as main_id, node_id, node_id_type, degree
-          from (
-            select m.{{input_material.Model.GetEntity().IdColumnName}}, e.node_id, e.node_id_type, count(*) as degree, row_number() over (partition by m.{{input_material.Model.GetEntity().IdColumnName}} order by count(*) desc) as rn
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+            select {{input_material.Model.GetEntity().IdColumnName}} as main_id, node_id, node_id_type, degree
             from (
-              select id1 as node_id, id1_type as node_id_type, B.{{input_material.Model.GetEntity().IdColumnName}} FROM {{input_material}}_INTERNAL_EDGES A inner join {{input_material}} B on A.id1 = B.other_id
-              where id1 <> id2
-              union all
-              select id2 as node_id, id2_type as node_id_type, B.{{input_material.Model.GetEntity().IdColumnName}} FROM {{input_material}}_INTERNAL_EDGES A inner join {{input_material}} B on A.id2 = B.other_id
-              where id1 <> id2
-            ) AS e
-            inner join {{input_material}} m on e.node_id = m.other_id
-            where m.{{input_material.Model.GetEntity().IdColumnName}} IN (
-              select {{input_material.Model.GetEntity().IdColumnName}}
-              from {{input_material}}
-              group by {{input_material.Model.GetEntity().IdColumnName}}
-              order by count(other_id) desc
-              limit 10
-            )
-            group by m.{{input_material.Model.GetEntity().IdColumnName}}, e.node_id, e.node_id_type
-          ) as ranked
-          where rn <= 10
+              select m.{{input_material.Model.GetEntity().IdColumnName}}, e.node_id, e.node_id_type, count(*) as degree, row_number() over (partition by m.{{input_material.Model.GetEntity().IdColumnName}} order by count(*) desc) as rn
+              from (
+                select id1 as node_id, id1_type as node_id_type, B.{{input_material.Model.GetEntity().IdColumnName}} FROM {{input_material}}_INTERNAL_EDGES A inner join {{input_material}} B on A.id1 = B.other_id
+                where id1 <> id2
+                union all
+                select id2 as node_id, id2_type as node_id_type, B.{{input_material.Model.GetEntity().IdColumnName}} FROM {{input_material}}_INTERNAL_EDGES A inner join {{input_material}} B on A.id2 = B.other_id
+                where id1 <> id2
+              ) AS e
+              inner join {{input_material}} m on e.node_id = m.other_id
+              where m.{{input_material.Model.GetEntity().IdColumnName}} IN (
+                select {{input_material.Model.GetEntity().IdColumnName}}
+                from {{input_material}}
+                group by {{input_material.Model.GetEntity().IdColumnName}}
+                order by count(other_id) desc
+                limit 10
+              )
+              group by m.{{input_material.Model.GetEntity().IdColumnName}}, e.node_id, e.node_id_type
+            ) as ranked
+            where rn <= 10
+          {% endif %}
         {% endwith %}
   - name: edges_graph
     model_type: sql_template
@@ -99,9 +105,11 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/top_max_degree_nodes") %}
-          select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
-          from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
-          where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+            select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
+            from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
+            where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
+          {% endif %}
         {% endwith %}
   - name: edges_biggest_cluster
     model_type: sql_template
@@ -112,10 +120,12 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/top_max_degree_nodes") input_material3 = this.DeRef("models/clusters_sorted_by_size") %}
-          select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
-          from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
-          where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
-            AND B.{{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material3}} limit 1)
+          {% if input_material1.Model.ModelType() == "id_stitcher_model" %}
+            select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
+            from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
+            where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
+              AND B.{{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material3}} limit 1)
+          {% endif %}
         {% endwith %}
   - name: id_type_count
     model_type: sql_template
@@ -126,11 +136,13 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          select A.{{input_material1.Model.GetEntity().IdColumnName}}, max(B.id_count) as total_id_count, 
-        other_id_type, count(other_id) as id_type_count
-          from {{input_material1}} A inner join {{input_material2}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}
-          group by A.{{input_material1.Model.GetEntity().IdColumnName}}, other_id_type
-          order by total_id_count desc , id_type_count desc
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+            select A.{{input_material1.Model.GetEntity().IdColumnName}}, max(B.id_count) as total_id_count, 
+          other_id_type, count(other_id) as id_type_count
+            from {{input_material1}} A inner join {{input_material2}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}
+            group by A.{{input_material1.Model.GetEntity().IdColumnName}}, other_id_type
+            order by total_id_count desc , id_type_count desc
+          {% endif %}
         {% endwith %}
   - name: id_count
     model_type: sql_template
@@ -141,13 +153,15 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          select id1_type, id1, count(id1) as total_instances, count(distinct {{input_material1.Model.GetEntity().IdColumnName}}) as merged_user_count
-          from {{input_material1}}_INTERNAL_EDGES
-          where id1 in (
-            select distinct other_id
-            from {{input_material1}}
-            where {{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material2}})
-            )
-          group by 1, 2
-          order by 3 desc;
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
+            select id1_type, id1, count(id1) as total_instances, count(distinct {{input_material1.Model.GetEntity().IdColumnName}}) as merged_user_count
+            from {{input_material1}}_INTERNAL_EDGES
+            where id1 in (
+              select distinct other_id
+              from {{input_material1}}
+              where {{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material2}})
+              )
+            group by 1, 2
+            order by 3 desc;
+          {% endif %}
         {% endwith %}

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -8,7 +8,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
             select sum(user_count) as user_count, max(other_id_count) as max_id_count,
               (sum(user_count * other_id_count)::float / sum(user_count)::float)::numeric(8,2) as avg_id_count
             from (
@@ -31,7 +31,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
             select count(distinct(node_id)) as id_count, max({{input_material.Model.GetEntity().IdColumnName}}_dist) as max_dist, {{input_material.Model.GetEntity().IdColumnName}}
             from {{input_material}}_INTERNAL_MAPPING
             group by {{input_material.Model.GetEntity().IdColumnName}}
@@ -72,7 +72,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("inputs/id_stitcher") %}
-          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material.Model.ModelType() == "id_stitcher_model" %}
             select {{input_material.Model.GetEntity().IdColumnName}} as main_id, node_id, node_id_type, degree
             from (
               select m.{{input_material.Model.GetEntity().IdColumnName}}, e.node_id, e.node_id_type, count(*) as degree, row_number() over (partition by m.{{input_material.Model.GetEntity().IdColumnName}} order by count(*) desc) as rn
@@ -105,7 +105,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/top_max_degree_nodes") %}
-          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material1.Model.ModelType() == "id_stitcher_model" %}
             select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
             from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
             where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
@@ -120,7 +120,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/top_max_degree_nodes") input_material3 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material1.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material1.Model.ModelType() == "id_stitcher_model" %}
             select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
             from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
             where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
@@ -136,7 +136,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material.Model.BaseWhtModel.modelType == "id_stitcher_model" %}
+          {% if input_material1.Model.ModelType() == "id_stitcher_model" %}
             select A.{{input_material1.Model.GetEntity().IdColumnName}}, max(B.id_count) as total_id_count, 
           other_id_type, count(other_id) as id_type_count
             from {{input_material1}} A inner join {{input_material2}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}
@@ -153,7 +153,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material1 = this.DeRef("inputs/id_stitcher") input_material2 = this.DeRef("models/clusters_sorted_by_size") %}
-          {% if input_material.Model.BaseWhtModel.ModelType() == "id_stitcher_model" %}
+          {% if input_material1.Model.ModelType() == "id_stitcher_model" %}
             select id1_type, id1, count(id1) as total_instances, count(distinct {{input_material1.Model.GetEntity().IdColumnName}}) as merged_user_count
             from {{input_material1}}_INTERNAL_EDGES
             where id1 in (


### PR DESCRIPTION
## Description of the change

added an if statement in single sql of models that use id stitcher model that checks that the model type is id_stitcher because before remapping during populate dependencies step the model type will be input model which do not have GetEntity method and the build will fail.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
