### PR TITLE
chore: update models to support RA3 nodes on Redshift

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -46,7 +46,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("models/clusters") %}
-          select * from {{input_material}}
+          select * from {{input_material.Name()}}
           order by id_count desc
           limit 10
         {% endwith %}
@@ -59,7 +59,7 @@ models:
         run_type: discrete
       single_sql: |
         {% with input_material = this.DeRef("models/clusters") %}
-          select * from {{input_material}}
+          select * from {{input_material.Name()}}
           order by max_dist desc
           limit 10
         {% endwith %}
@@ -83,10 +83,10 @@ models:
                 select id2 as node_id, id2_type as node_id_type, B.{{input_material.Model.GetEntity().IdColumnName}} FROM {{input_material}}_INTERNAL_EDGES A inner join {{input_material}} B on A.id2 = B.other_id
                 where id1 <> id2
               ) AS e
-              inner join {{input_material}} m on e.node_id = m.other_id
+              inner join {{input_material.Name()}} m on e.node_id = m.other_id
               where m.{{input_material.Model.GetEntity().IdColumnName}} IN (
                 select {{input_material.Model.GetEntity().IdColumnName}}
-                from {{input_material}}
+                from {{input_material.Name()}}
                 group by {{input_material.Model.GetEntity().IdColumnName}}
                 order by count(other_id) desc
                 limit 10
@@ -108,7 +108,7 @@ models:
           {% if input_material1.Model.ModelType() == "id_stitcher" %}
             select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
             from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
-            where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
+            where id1 <> id2 AND id1 in (select node_id from {{input_material2.Name()}}) AND id2 in (select node_id from {{input_material2.Name()}})
           {% endif %}
         {% endwith %}
   - name: edges_biggest_cluster
@@ -123,8 +123,8 @@ models:
           {% if input_material1.Model.ModelType() == "id_stitcher" %}
             select id1, id1_type, id2, id2_type, B.{{input_material1.Model.GetEntity().IdColumnName}} as main_id
             from {{input_material1}}_INTERNAL_EDGES A inner join {{input_material1}} B on A.id1 = B.other_id
-            where id1 <> id2 AND id1 in (select node_id from {{input_material2}}) AND id2 in (select node_id from {{input_material2}})
-              AND B.{{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material3}} limit 1)
+            where id1 <> id2 AND id1 in (select node_id from {{input_material2.Name()}}) AND id2 in (select node_id from {{input_material2.Name()}})
+              AND B.{{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material3.Name()}} limit 1)
           {% endif %}
         {% endwith %}
   - name: id_type_count
@@ -139,7 +139,7 @@ models:
           {% if input_material1.Model.ModelType() == "id_stitcher" %}
             select A.{{input_material1.Model.GetEntity().IdColumnName}}, max(B.id_count) as total_id_count, 
           other_id_type, count(other_id) as id_type_count
-            from {{input_material1}} A inner join {{input_material2}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}
+            from {{input_material1}} A inner join {{input_material2.Name()}} B on A.{{input_material1.Model.GetEntity().IdColumnName}} = B.{{input_material1.Model.GetEntity().IdColumnName}}
             group by A.{{input_material1.Model.GetEntity().IdColumnName}}, other_id_type
             order by total_id_count desc , id_type_count desc
           {% endif %}
@@ -159,7 +159,7 @@ models:
             where id1 in (
               select distinct other_id
               from {{input_material1}}
-              where {{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material2}})
+              where {{input_material1.Model.GetEntity().IdColumnName}} in (select {{input_material1.Model.GetEntity().IdColumnName}} from {{input_material2.Name()}})
               )
             group by 1, 2
             order by 3 desc;

--- a/models/reports.yaml
+++ b/models/reports.yaml
@@ -61,7 +61,7 @@ models:
             {% set query_models = ["models/clusters", "models/overall_stats", "models/clusters_sorted_by_size", "models/clusters_sorted_by_dist", "models/top_max_degree_nodes", "models/edges_graph", "models/edges_biggest_cluster", "models/id_type_count", "models/id_count"] %}
             {% for qmodel in query_models %}
               {% with table = this.DeRef(qmodel).RunEphemeralSelector(-1) %}
-                {{ table.Save(this.DeRef(qmodel).GetWhtContext().OutputFolder()+"/reports/"+this.DeRef(qmodel).String()+".json") }}
+                {{ table.Save(this.DeRef(qmodel).GetWhtContext().OutputFolder()+"/reports/"+this.DeRef(qmodel).Name()+".json") }}
                 <div class="table-container">
                     <h3>{{ this.DeRef(qmodel).GetModel().Name() }}</h3>
                     <table>


### PR DESCRIPTION
## Description of the change
Update the SQL models to use names only wherever required on order to support the RA3 nodes on Redshift since it creates late binding views.

RA3 nodes on Redshift
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[Actual PR Link on WHT Side](https://github.com/rudderlabs/wht/pull/860)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
