### PR TITLE
fix: add dummy id types to satisfy validations

### DIFF
--- a/pb_project.yaml
+++ b/pb_project.yaml
@@ -13,3 +13,7 @@ model_folders:
 # Entities in this project and their ids.
 entities:
   - name: NA
+    id_types:
+      - na_id
+id_types:
+  - name: na_id


### PR DESCRIPTION
## Description of the change

Currently the tests are failing in wht if entity id types are made mandatory. Adding dummy id types to fix that issue

https://linear.app/rudderstack/issue/PRO-2011/add-validations-for-entity-id-types

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
