### PR TITLE
fix: syntax error when running IdStitcherReport in bigquery

### DIFF
--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -147,12 +147,12 @@ models:
                         AND ids.{{id_column_name}}
                             IN (
                                 {% if !seed_clusters_optional.IsNil() %}
-                                SELECT {{id_column_name}} FROM {{seed_clusters_optional}}
+                                SELECT DISTINCT {{id_column_name}} FROM {{seed_clusters_optional}}
                                 UNION
                                 {% endif %}
-                                SELECT {{id_column_name}} FROM {{clusters_sorted_by_size}}
+                                SELECT DISTINCT {{id_column_name}} FROM {{clusters_sorted_by_size}}
                                 UNION
-                                SELECT {{id_column_name}} FROM {{clusters_sorted_by_dist}}
+                                SELECT DISTINCT {{id_column_name}} FROM {{clusters_sorted_by_dist}}
                             )
                 {% endwith %}
                 {% endwith %}

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -147,12 +147,12 @@ models:
                         AND ids.{{id_column_name}}
                             IN (
                                 {% if !seed_clusters_optional.IsNil() %}
-                                SELECT DISTINCT {{id_column_name}} FROM {{seed_clusters_optional}}
-                                UNION
+                                SELECT {{id_column_name}} FROM {{seed_clusters_optional}}
+                                UNION {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
                                 {% endif %}
-                                SELECT DISTINCT {{id_column_name}} FROM {{clusters_sorted_by_size}}
-                                UNION
-                                SELECT DISTINCT {{id_column_name}} FROM {{clusters_sorted_by_dist}}
+                                SELECT {{id_column_name}} FROM {{clusters_sorted_by_size}}
+                                UNION {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
+                                SELECT {{id_column_name}} FROM {{clusters_sorted_by_dist}}
                             )
                 {% endwith %}
                 {% endwith %}

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -149,11 +149,15 @@ models:
                                 {% if !seed_clusters_optional.IsNil() %}
                                 SELECT {{id_column_name}} FROM {{seed_clusters_optional}}
                                 UNION 
-                                {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
+                                  {% if warehouse.DatabaseType() == "bigquery" %} 
+                                    DISTINCT 
+                                  {% endif %}
                                 {% endif %}
                                 SELECT {{id_column_name}} FROM {{clusters_sorted_by_size}}
                                 UNION 
-                                {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
+                                  {% if warehouse.DatabaseType() == "bigquery" %} 
+                                    DISTINCT 
+                                  {% endif %}
                                 SELECT {{id_column_name}} FROM {{clusters_sorted_by_dist}}
                             )
                 {% endwith %}

--- a/models/profiles.yaml
+++ b/models/profiles.yaml
@@ -148,10 +148,12 @@ models:
                             IN (
                                 {% if !seed_clusters_optional.IsNil() %}
                                 SELECT {{id_column_name}} FROM {{seed_clusters_optional}}
-                                UNION {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
+                                UNION 
+                                {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
                                 {% endif %}
                                 SELECT {{id_column_name}} FROM {{clusters_sorted_by_size}}
-                                UNION {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
+                                UNION 
+                                {%- if warehouse.DatabaseType() == "bigquery" -%} DISTINCT {%- endif -%}
                                 SELECT {{id_column_name}} FROM {{clusters_sorted_by_dist}}
                             )
                 {% endwith %}


### PR DESCRIPTION
## Description of the change

Issue:
"Expected keyword ALL or keyword DISTINCT but got keyword SELECT" error in BigQuery.
Cause:
Using a subquery with UNION within the IN operator without specifying DISTINCT or ALL in single sql for edges_in_chosen_clusters model.
Resolution:
Modified the subquery to use UNION DISTINCT and added DISTINCT to the subqueries to ensure removal of duplicates for bigquery.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
